### PR TITLE
Fixes autocomplete with only 1 search field

### DIFF
--- a/jet/forms.py
+++ b/jet/forms.py
@@ -109,7 +109,10 @@ class ModelLookupForm(forms.Form):
         if self.cleaned_data['q']:
             if getattr(self.model_cls, 'autocomplete_search_fields', None):
                 search_fields = self.model_cls.autocomplete_search_fields()
-                filter_data = [Q((field + '__icontains', self.cleaned_data['q'])) for field in search_fields]
+                if len(search_fields) > 1:
+                    filter_data = [Q((field + '__icontains', self.cleaned_data['q'])) for field in search_fields]
+                else:
+                    filter_data = [Q((search_fields + '__icontains', self.cleaned_data['q']))]
                 # if self.cleaned_data['object_id']:
                 #     filter_data.append(Q(pk=self.cleaned_data['object_id']))
                 qs = qs.filter(reduce(operator.or_, filter_data))


### PR DESCRIPTION
Previously would break because it would split the field into characters. Example:

models.py
......
return 'client'

forms.py
for field in search fields:
field = 'c'
field = 'l'
field = 'i'
etc
